### PR TITLE
Removed two unused lines in serverWebpackConfig.js

### DIFF
--- a/config/webpack/serverWebpackConfig.js
+++ b/config/webpack/serverWebpackConfig.js
@@ -100,10 +100,6 @@ const configureServer = () => {
     }
   });
 
-  // TODO: DELETE NEXT 2 LINES
-  // Critical due to https://github.com/rails/webpacker/pull/2644
-  // delete serverWebpackConfig.devServer
-
   // eval works well for the SSR bundle because it's the fastest and shows
   // lines in the server bundle which is good for debugging SSR
   // The default of cheap-module-source-map is slow and provides poor info.


### PR DESCRIPTION
There were two lines in serverWebpackConfig.js that had a TODO delete above them. I figured I'd delete them since I noticed them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails_demo_ssr_hmr/39)
<!-- Reviewable:end -->
