### PR TITLE
Add reference to swc demo branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ bin/dev-static
 overmind start -f Procfile.dev-static
 ```
 
+## Running with SWC
+
+Starting from Shakapacker 6.1.1, it is possible to use SWC in projects.
+See
+[tomdracz/swc-config](https://github.com/shakacode/react_on_rails_demo_ssr_hmr/tree/tomdracz/swc-config)
+branch for a demonstration of SWC usage.
+
+Please check out
+[Shakapacker - Using SWC Loader](https://github.com/shakacode/shakapacker/blob/master/docs/using_swc_loader.md)
+documentation for more information about this feature.
+
 ## Testing Functionality of SSR and HMR
 
 1. Start app using either `bin/dev` or `bin/dev-static` (or run `Procfile.dev` or `Procfile.dev-static` with your favorit process manager like overmind or foreman).


### PR DESCRIPTION
As per previous discussions, we keep [tomdracz/swc-config](https://github.com/shakacode/react_on_rails_demo_ssr_hmr/tree/tomdracz/swc-config) branch unmerged as a demo. This PR adds a reference in the README file to this branch.

If everything is set, I recommend renaming the mentioned branch into `demo-branch-for-swc-loader`. This name, besides being descriptive, reduces the chance of being deleted by mistake.

Closes #56

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails_demo_ssr_hmr/61)
<!-- Reviewable:end -->
