### PR TITLE
Bump React on Rails to 17.0.0-rc.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 
 /public/packs
 /public/packs-test
+/ssr-generated
 /node_modules
 
 .pnp.*

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "shakapacker", "8.0.0"
-gem "react_on_rails", "17.0.0.rc.3"
+gem "react_on_rails", "17.0.0.rc.6"
 
 gem "net-smtp", "~> 0.3.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    react_on_rails (17.0.0.rc.3)
+    react_on_rails (17.0.0.rc.6)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -250,7 +250,7 @@ DEPENDENCIES
   psych (< 4)
   puma (~> 4.1)
   rails (~> 6.1)
-  react_on_rails (= 17.0.0.rc.3)
+  react_on_rails (= 17.0.0.rc.6)
   rspec-rails (~> 6.0.0)
   selenium-webdriver (>= 4.9)
   shakapacker (= 8.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.7)
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3)

--- a/bin/shakapacker
+++ b/bin/shakapacker
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] ||= "development"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
 require "bundler/setup"
+require "logger"
 require "shakapacker"
 require "shakapacker/webpack_runner"
 

--- a/bin/shakapacker-dev-server
+++ b/bin/shakapacker-dev-server
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] ||= "development"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
 require "bundler/setup"
+require "logger"
 require "shakapacker"
 require "shakapacker/dev_server_runner"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require_relative 'boot'
 
+require "logger"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"

--- a/config/webpack/serverWebpackConfig.js
+++ b/config/webpack/serverWebpackConfig.js
@@ -9,6 +9,7 @@ const configureServer = () => {
   // entry value will result in changing the client config!
   // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig()
+  const publicPath = serverWebpackConfig.output.publicPath
 
   // We just want the single server bundle entry
   const serverEntry = {
@@ -49,7 +50,7 @@ const configureServer = () => {
     // If using the React on Rails Pro node server renderer, uncomment the next line
     // libraryTarget: 'commonjs2',
     path: resolve(__dirname, '../../ssr-generated'),
-    publicPath: '',
+    publicPath,
     // https://webpack.js.org/configuration/output/#outputglobalobject
   }
 

--- a/config/webpack/serverWebpackConfig.js
+++ b/config/webpack/serverWebpackConfig.js
@@ -1,7 +1,7 @@
-const { merge, config } = require('shakapacker')
 const commonWebpackConfig = require('./commonWebpackConfig')
 
 const webpack = require('webpack')
+const { resolve } = require('path')
 
 const configureServer = () => {
   // We need to use "merge" because the clientConfigObject, EVEN after running
@@ -48,8 +48,8 @@ const configureServer = () => {
     globalObject: 'this',
     // If using the React on Rails Pro node server renderer, uncomment the next line
     // libraryTarget: 'commonjs2',
-    path: config.outputPath,
-    publicPath: config.publicPath,
+    path: resolve(__dirname, '../../ssr-generated'),
+    publicPath: '',
     // https://webpack.js.org/configuration/output/#outputglobalobject
   }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pnp-webpack-plugin": "^1.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-on-rails": "17.0.0-rc.3",
+    "react-on-rails": "17.0.0-rc.6",
     "shakapacker": "8.0.0",
     "style-loader": "^3.3.2",
     "terser-webpack-plugin": "^5.3.8",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,7 @@ RSpec.configure do |config|
 
   # Capybara config
   config.include Capybara::DSL
+  ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
   #
   # selenium_firefox webdriver only works for Travis-CI builds.
   default_driver = :selenium_chrome_headless

--- a/yarn.lock
+++ b/yarn.lock
@@ -6801,13 +6801,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-on-rails@npm:17.0.0-rc.3":
-  version: 17.0.0-rc.3
-  resolution: "react-on-rails@npm:17.0.0-rc.3"
+"react-on-rails@npm:17.0.0-rc.6":
+  version: 17.0.0-rc.6
+  resolution: "react-on-rails@npm:17.0.0-rc.6"
   peerDependencies:
     react: ">= 16"
     react-dom: ">= 16"
-  checksum: 998f8d0ec7988f87d532a23f384da88dd7e75a56d517579ee689d182f5cb718139807dbee1f8792f02d41d66ffe0c36b857af62ff0d7737197f6607bcb5d1d90
+  checksum: 51d199a7b0a42d8cf5a74a07df14817ee173edc34962b1ba692042b800e06ef6523e3aa13d808315adef71ba2f0d0a2e6041e7c7294a745ca7f0ad1f903989d8
   languageName: node
   linkType: hard
 
@@ -7168,7 +7168,7 @@ __metadata:
     pnp-webpack-plugin: ^1.7.0
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-on-rails: 17.0.0-rc.3
+    react-on-rails: 17.0.0-rc.6
     react-refresh: ^0.14.0
     shakapacker: 8.0.0
     style-loader: ^3.3.2


### PR DESCRIPTION
## Summary
- Bumps react-on-rails to 17.0.0-rc.6.
- Bumps the react_on_rails gem to 17.0.0.rc.6.
- Regenerates yarn.lock and Gemfile.lock.

## Validation
- corepack yarn install --mode=update-lockfile
- bundle install
- git diff --check
- Scanned manifests and lockfiles for stale RC pins.