### PR TITLE
Validate React on Rails 17 RC 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,6 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "shakapacker", "10.2.0"
-gem "react_on_rails", "17.0.0.rc.6"
+gem "react_on_rails", "17.0.0.rc.9"
 
 gem "net-smtp", "~> 0.5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       prism (>= 1.6.0)
       rbs (>= 4.0.0)
       tsort
-    react_on_rails (17.0.0.rc.6)
+    react_on_rails (17.0.0.rc.9)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -305,7 +305,7 @@ DEPENDENCIES
   net-smtp (~> 0.5.1)
   puma (~> 8.0)
   rails (~> 8.1)
-  react_on_rails (= 17.0.0.rc.6)
+  react_on_rails (= 17.0.0.rc.9)
   rspec-rails (~> 8.0.4)
   selenium-webdriver (>= 4.9)
   shakapacker (= 10.2.0)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pnp-webpack-plugin": "^1.7.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-on-rails": "17.0.0-rc.6",
+    "react-on-rails": "17.0.0-rc.9",
     "shakapacker": "10.2.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7061,13 +7061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-on-rails@npm:17.0.0-rc.6":
-  version: 17.0.0-rc.6
-  resolution: "react-on-rails@npm:17.0.0-rc.6"
+"react-on-rails@npm:17.0.0-rc.9":
+  version: 17.0.0-rc.9
+  resolution: "react-on-rails@npm:17.0.0-rc.9"
   peerDependencies:
     react: ">= 16"
     react-dom: ">= 16"
-  checksum: 51d199a7b0a42d8cf5a74a07df14817ee173edc34962b1ba692042b800e06ef6523e3aa13d808315adef71ba2f0d0a2e6041e7c7294a745ca7f0ad1f903989d8
+  checksum: 56416568b4d15cc7c2b63528b7542070b2afc05595e9506a0db823906b3470bd38260dd511c5f0cdf2e49a80bdf96889efe5f6e05f92f63915f9c3f58f97e013
   languageName: node
   linkType: hard
 
@@ -7434,7 +7434,7 @@ __metadata:
     pnp-webpack-plugin: ^1.7.0
     react: ^19.2.7
     react-dom: ^19.2.7
-    react-on-rails: 17.0.0-rc.6
+    react-on-rails: 17.0.0-rc.9
     react-refresh: ^0.18.0
     shakapacker: 10.2.0
     style-loader: ^4.0.0


### PR DESCRIPTION
## Summary

- Update `react_on_rails` and `react-on-rails` from RC6 to RC9.
- Keep Shakapacker and unrelated dependencies unchanged.

## Validation

- `bundle check` and Yarn 3 immutable install
- Exact installed gem/npm version checks
- RSpec: 2 examples, 0 failures with a Chrome-compatible driver path
- Production client/server asset precompile
- Direct Rails integration request: 200 with server-rendered markup
- Development Shakapacker server compiled with React Refresh and HMR, then shut down cleanly
- `git diff --check`
- Targeted independent/manual review: clean

The external `codex review` transport degraded after repeated websocket/DNS reconnects. The exact four-file diff was manually re-reviewed and is supported by the runtime, production build, and HMR validation above.

## Lockfile audit

Only the requested direct gem/npm package locator, version, resolution, checksum, and root pin changed. No transitive, platform, native/precompiled, source-build, or build-time dependency changed.

### QA Evidence

- QA lane: `codex-rc9-qa`
- Scope checked: exact four-file dependency diff, production SSR build/request, and development HMR path
- Tested at: `0b8b5d802aa2a09fc4136837c466ced81b37c73c`
- Automated checks: listed above
- Manual checks: exact diff review after external reviewer transport degradation
- Findings: none
- QA required: yes
- QA required rationale: SSR/HMR release-candidate update
- QA lane status: satisfied with reviewer-transport limitation
- Release-blocking status: clear
- Process-gap disposition: checklist+replay

<!-- qa-evidence v1
required: yes
status: satisfied
head_sha: 0b8b5d802aa2a09fc4136837c466ced81b37c73c
tested_at: 0b8b5d802aa2a09fc4136837c466ced81b37c73c
scope: RC9 gem/npm locks, production SSR build/request, and development HMR compilation
automated_checks: bundle check; immutable yarn; RSpec; production assets; Rails SSR request; HMR dev-server compile; diff check
manual_checks: exact diff manual review after codex review transport degradation
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

<!-- priority-finding-dispositions v1
status: not_applicable
head_sha: 0b8b5d802aa2a09fc4136837c466ced81b37c73c
-->

Confidence note: High for the scoped two-package update because production SSR and development HMR paths pass; external review transport was degraded. Merge authority remains with maintainers.
