### PR TITLE
Configure direct merge submission

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -13,4 +13,6 @@ merge_ledger: n/a
 ci_parity_environment: n/a — reproduce CI-only failures from the matching job in .github/workflows/**
 hosted_ci_trigger: n/a — CI runs on every PR if configured
 ci_change_detector: n/a
+merge_submission:
+  mode: direct
 repo_prefix: RORSH


### PR DESCRIPTION
## Summary

Explicitly set `merge_submission.mode: direct` so this repository keeps the portable direct path after shared workflow upgrades.

## Validation

- Parsed `.agents/agent-workflow.yml` with Bundler Ruby.
- Ran the merged-source agent-workflow seam doctor.
- Checked the one-file diff for whitespace errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured submissions to use direct merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->